### PR TITLE
Allow that versioned files are created next to the source file.

### DIFF
--- a/tasks/version.js
+++ b/tasks/version.js
@@ -48,8 +48,11 @@ Elixir.extend('version', function(src, buildPath) {
             .on('end', function() {
                 // We'll get rid of the duplicated file that
                 // usually gets put in the "build" folder,
-                // alongside the suffixed version.
-                del(files.paths, { force: true });
+                // alongside the suffixed version, just if
+                // buildFolder is different of assetsPath
+                if (isExternalBuildPath(buildPath)) {
+                    del(files.paths, { force: true });
+                }
 
                 // We'll also copy over relevant sourcemap files.
                 copyMaps(paths.src.path, paths.output.baseDir);
@@ -124,3 +127,15 @@ var copyMaps = function(src, buildPath) {
         });
     });
 };
+
+/**
+ * Return true if buildFolder is different of assetsPath, instead return false
+ * @param buildPath
+ * @returns {boolean}
+ */
+var isExternalBuildPath = function(buildPath) {
+    var customBuildPath = buildPath || config.get('public.versioning.buildFolder');
+
+    return customBuildPath !== Elixir.config.assetsPath;
+};
+


### PR DESCRIPTION
This tittle change allow to created versioned file next to source file, just if assestPath and buildFolder have the same value.

I tested this change overriding assetsPath and buildFolder values from gulpfile.js, elixir.json and specifying a second parameter of mix.version([files], "public" ) task, please take a look:

Overriding elixir configuration from gulpfile.js:

``` javascript
// Load Laravel elixir
var Elixir = require('laravel-elixir');

// Get elixir configuration
var config = Elixir.config;

// Overwrite assetPath
config.assetsPath = 'public';

// Overwrite buildFolder
config.versioning.buildFolder = '';

Elixir(function(mix) {
    mix.version([
        // replace css files path with yours
        config.assetsPath + '/css/user.css',
        config.assetsPath + '/css/contact.css',

        // replace script files path with yours
        config.assetsPath + '/js/user.js',
        config.assetsPath + '/js/contact.js'
    ]);
});
```

Overriding elixir configuration from gulpfile.js second option:

``` javascript
...
// Overwrite assetPath
config.assetsPath = 'public';

Elixir(function(mix) {
    mix.version([
        // replace css files path with yours
        config.assetsPath + '/css/user.css',
        config.assetsPath + '/css/contact.css',

        // replace script files path with yours
        config.assetsPath + '/js/user.js',
        config.assetsPath + '/js/contact.js'
    ], 'public');
});
```

Overriding elixir configuration using elixir.json file:

``` javascript
{
  "assetsPath": "public",

  "versioning": {
    "buildFolder": ""
  }
}
```

Output will looks like this:

```
public
└─ css
 └─ user.css
 └─ user-8fa778f76c.css
 └─ contact.css
 └─ contact-b45e8b679c.css
└─ js
 └─ user.js
 └─ user-676f8ea6c9.js
 └─ contact.js
 └─ contact-8e660751aa.js
└─ rev-manifest.json
```

Finally the rev-manifest.json file looks good as well:

``` json
{
  "css/user.css": "css/user-8fa778f76c.css",
  "css/contact.css": "css/contact-b45e8b679c.css",
  "js/user.js": "js/user-676f8ea6c9.js",
  "js/contact.js": "js/contact-8e660751aa.js"
}
```

Please, let me know any doubts or concerns.
